### PR TITLE
fix(NuxtLink): observer is null

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -506,9 +506,9 @@ function useObserver (): { observe: ObserveFn } | undefined {
     observer.observe(element)
     return () => {
       callbacks.delete(element)
-      observer!.unobserve(element)
+      observer?.unobserve(element)
       if (callbacks.size === 0) {
-        observer!.disconnect()
+        observer?.disconnect()
         observer = null
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

This fixes a crash of the app if there is a "conflict" between the `unobserve` from the `onMounted`/`onNuxtReady` and from the `onBeforeUnmount` -- meaning the "unobserve" function (return of `observe()`) is called twice.

<img width="667" alt="image" src="https://github.com/user-attachments/assets/8db3a1e3-4431-4e5e-b8bc-992e1a0b132a">


<img width="513" alt="image" src="https://github.com/user-attachments/assets/c477178c-7ad8-40fe-88d9-62d31a682915">


Then `observer` is already null and this causes the crash.

<img width="1656" alt="image" src="https://github.com/user-attachments/assets/15d490ef-4a18-4482-8b90-daaad14d710a">
<img width="1655" alt="image" src="https://github.com/user-attachments/assets/f47ce429-a409-46fa-b770-6fc4a801880b">

